### PR TITLE
Order API changes

### DIFF
--- a/resources/order.md
+++ b/resources/order.md
@@ -580,6 +580,135 @@ Re-open a closed Order
 }
 ```
 
+### POST /orders/#{id}/fulfill
+
+Fulfill an Order
+
+| Parameter                    | Explanation                                                                        |
+| ---------------------------- | ---------------------------------------------------------------------------------- |
+| shipping_tracking_number     | Shipment's tracking number provided by the shipping company                        |
+| notify_customer              | Notify the customer of the cancellation (the default value is true)                |
+
+#### POST /orders/450789469/fulfill
+
+```json
+{
+    "shipping_tracking_number": "ABC1234",
+    "notify_customers": true
+}
+```
+
+`HTTP/1.1 200 OK`
+
+```json
+{
+    "cancel_reason": null,
+    "created_at": "2008-01-10T11:00:00-05:00",
+    "currency": "USD",
+    "gateway": "paypal",
+    "id": 450789469,
+    "landing_site": "http://www.example.com?source=abc",
+    "language": "en",
+    "location_id": null,
+    "name": "#1001",
+    "note": null,
+    "number": 1,
+    "owner_note": null,
+    "payment_status": "pending",
+    "shipping": "ups",
+    "shipping_status": "shipped",
+    "shipping_tracking_number": "ABC1234",
+    "shipping_min_days": 2,
+    "shipping_max_days": 4,
+    "shipping_cost_owner": "20.00",
+    "shipping_cost_customer": "20.00",
+    "status": "open",
+    "subtotal": "38.00",
+    "token": "898544a54283414238f74cd08f0efd3916f74b75",
+    "discount": "0.00",
+    "price": "58.00",
+    "price_usd": "58.00",
+    "weight": "2.00",
+    "updated_at": "2008-01-10T11:00:00-05:00",
+    "shipped_at": "2008-01-10T11:00:00-05:00",
+    "number": 101,
+    "coupon": [
+      {
+        "code": "SUPERDISCOUNT"
+      }
+    ],
+    "products": [
+      {
+        "depth": null,
+        "height": null,
+        "price": "19.00",
+        "product_id": 1234,
+        "quantity": 2,
+        "free_shipping": false,
+        "variant_id": 101,
+        "weight": "2.00",
+        "width": null
+      }
+    ],
+    "billing_address": "Evergreen Terrace",
+    "billing_city": "Springfield",
+    "billing_country": "US",
+    "billing_default": true,
+    "billing_floor": null,
+    "billing_locality": null,
+    "billing_number": "742",
+    "billing_phone": "555-123-0413",
+    "billing_province": "Oregon",
+    "billing_zipcode": "97475",
+    "extra": {
+      "gift-wrap": "deluxe"
+    },
+    "shipping_pickup_type": "ship",
+    "shipping_store_branch_name": null,
+    "shipping_address": {
+      "address": "Evergreen Terrace",
+      "city": "Springfield",
+      "country": "US",
+      "created_at": "2013-01-03T09:11:51-03:00",
+      "default": true,
+      "floor": null,
+      "id": 1234,
+      "locality": null,
+      "number": "742",
+      "phone": "555-123-0413",
+      "province": "Oregon",
+      "updated_at": "2013-03-10T11:13:01-03:00",
+      "zipcode": "97475"
+    },
+    "customer": {
+      "created_at": "2013-01-03T09:11:51-03:00",
+      "email": "john.doe@example.com",
+      "id": 101,
+      "last_order_id": 9001,
+      "name": "John Doe",
+      "total_spent": "89.00",
+      "total_spent_currency": "USD",
+      "updated_at": "2013-03-11T09:14:11-03:00",
+      "default_address": {
+        "address": "Evergreen Terrace",
+        "city": "Springfield",
+        "country": "US",
+        "created_at": "2013-01-03T09:11:51-03:00",
+        "default": true,
+        "floor": null,
+        "id": 1234,
+        "locality": null,
+        "number": "742",
+        "phone": "555-123-0413",
+        "province": "Oregon",
+        "updated_at": "2013-03-10T11:13:01-03:00",
+        "zipcode": "97475"
+      }
+    }
+}
+```
+
+
 ### POST /orders/#{id}/cancel
 
 Cancel an Order
@@ -704,13 +833,14 @@ Cancel an Order
 
 ### PUT /orders/#{id}
 
-Change the Order's owner_note (the only value you can modify through the API)
+Change an Order's attributes (just `owner_note` for now) and/or update an Order's status
 
 #### PUT /orders/450789469
 
 ```json
 {
-    "owner_note": "Need to gift wrap this order"
+    "owner_note": "Need to gift wrap this order",
+    "status": "paid"
 }
 ```
 
@@ -730,7 +860,7 @@ Change the Order's owner_note (the only value you can modify through the API)
     "note": null,
     "number": 1,
     "owner_note": "Need to gift wrap this order",
-    "payment_status": "pending",
+    "payment_status": "paid",
     "shipping": "ups",
     "shipping_status": "unshipped",
     "shipping_tracking_number": null,


### PR DESCRIPTION
- Adding `POST /orders/(:num)/fulfill` endpoint 
- `status` can now be sent to `PUT /orders/(:num)/` endpoint