### PR TITLE
jQuery version validation fix

### DIFF
--- a/resources/script.md
+++ b/resources/script.md
@@ -41,7 +41,14 @@ var myAppJavaScript = function($){
   $('body').append("<p>I'm using jQuery version "+$.fn.jquery+'</p>');
 };
 
-if ((typeof jQuery === 'undefined') || (parseFloat(jQuery.fn.jquery) < 1.7)) {
+// For jQuery version 1.7
+var target = [1, 7, 0];
+
+var current = typeof jQuery === 'undefined' ? [0,0,0] : $.fn.jquery.split('.').map(function(item) {
+    return parseInt(item);
+});
+
+if (current[0] < target[0] || (current[0] == target[0] && current[1] < target[1])) {
   loadScript('//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js', function(){
     var jQuery1101 = jQuery.noConflict(true);
     myAppJavaScript(jQuery1101);


### PR DESCRIPTION
`(parseFloat(jQuery.fn.jquery) < 1.7)` is false when jQuery version is ≥ 1.10 because of literal comparison.