### PR TITLE
Atualizada a informação do preço que é retornado pela API

### DIFF
--- a/resources/product_variant.md
+++ b/resources/product_variant.md
@@ -11,7 +11,7 @@ Properties
 | id                | The unique numeric identifier for the Product Variant                                           |
 | image_id          | The id of the product's image associated with the variant                                       |
 | product_id        | The id of the product associated with the variant                                               |
-| price             | Price of the Product Variant. *null* indicates the product will initiate a contact instead of a checkout process |
+| price             | Price of the Product Variant. *null* indicates the product will initiate a contact instead of a checkout process.<br><br>**Note:** The price returned will be the one configured in the product in the store's default currenty. The API won't return the price converted to another currency.|
 | promotional_price | Lower price to display as a sale. The value of price will be displayed crossed out for comparison                |
 | stock_management  | Specifies whether or not Tienda Nube/Nuvem Shop tracks the number of items in stock for this product variant. Valid values are *true* if Tienda Nube/Nuvem Shop tracks the stock, *false* if it doesn't.|
 | stock             | Stock of the Product Variant. If `stock_management` is false the stock will be null             |


### PR DESCRIPTION
O preço do produto quando retornado pela API não vem junto com o valor convertido para outras moedas que a loja tiver em sua configurado. Mas isso não é dito na documentação.

Isso porque levar o desenvovedor a perder algumas horas pois até ele entender que a conversão tem que ser feito depois da API, pode levar tempo.