### PR TITLE
Adjust checkout payment lib doc

### DIFF
--- a/resources/checkout.md
+++ b/resources/checkout.md
@@ -404,7 +404,7 @@ These are the fields rendered and available on the `Checkout.data.form` object.
 
 | Name                  | Description                                            | Required     | `fields` value           |
 | --------------------- | ------------------------------------------------------ | ------------ | ------------------------ |
-| `brand`               | Card brand. E.g. `visa`, `master`, etc.                | Always       |                          |
+| `cardBrand`           | Card brand. E.g. `visa`, `master`, etc.                | Always       |                          |
 | `cardNumber`          | Card number.                                           | Always       |                          |
 | `cardHolderName`      | Card holder's name.                                    | Always       |                          |
 | `cardExpiration`      | Card's expiration date in `mm/yy` format.              | Always       |                          |
@@ -439,10 +439,9 @@ These are the input fields rendered and available in the object `Checkout.data.f
 
 These are the input fields rendered and available in the object `Checkout.data.form`.
 
-| Name             | Description                                        | Required     | `fields` value       |
-| ---------------- | -------------------------------------------------- | ------------ | -------------------- |
-| `holderName`     | Consumer name.                                     | Optional     | `boleto_holder_name` |
-| `holderIdNumber` | Consumer identification (DNI, CUIT or equivalent). | Optional     | `efectivo_list`      |
+| Name    | Description                                  | Required     | `fields` value       |
+| --------| -------------------------------------------- | ------------ | -------------------- |
+| `brand` | Brand name for selected efectivo list option | Always       | `efectivo_list`      |
 
 #### `PaymentOption` Configuration Object and it's properties
 

--- a/resources/checkout.md
+++ b/resources/checkout.md
@@ -441,7 +441,7 @@ These are the input fields rendered and available in the object `Checkout.data.f
 
 | Name    | Description                                  | Required     | `fields` value       |
 | --------| -------------------------------------------- | ------------ | -------------------- |
-| `brand` | Brand name for selected efectivo list option | Always       | `efectivo_list`      |
+| `brand` | Brand name for selected cash list option     | Always       | `efectivo_list`      |
 
 #### `PaymentOption` Configuration Object and it's properties
 

--- a/resources/checkout.md
+++ b/resources/checkout.md
@@ -404,7 +404,6 @@ These are the fields rendered and available on the `Checkout.data.form` object.
 
 | Name                  | Description                                            | Required     | `fields` value           |
 | --------------------- | ------------------------------------------------------ | ------------ | ------------------------ |
-| `cardBrand`           | Card brand. E.g. `visa`, `master`, etc.                | Always       |                          |
 | `cardNumber`          | Card number.                                           | Always       |                          |
 | `cardHolderName`      | Card holder's name.                                    | Always       |                          |
 | `cardExpiration`      | Card's expiration date in `mm/yy` format.              | Always       |                          |
@@ -415,6 +414,8 @@ These are the fields rendered and available on the `Checkout.data.form` object.
 | `cardHolderBirthDate` | Card holder's birthday in `dd/mm/yy` format.           | Optional     | `card_holder_birth_date` |
 | `cardHolderPhone`     | Card holder's phone number.                            | Optional     | `card_holder_phone`      |
 | `bankId`              | Card's issuing bank.                                   | Optional     | `bankList`               |
+
+> `cardBrand` is inserted after the user enters the first six credit card numbers
 
 ##### DebitPayment
 


### PR DESCRIPTION
Alterando o campo `brand` para `cardBrand` nos campos de cartão de crédito e ajustando os campos do template de Ticket.
O template de ticket possui apenas um campo `efectivo_list` e seu valor nos dados do formulário é `brand`