### PR TITLE
 Installments only allowed for credit_card method type

### DIFF
--- a/resources/payment_provider.md
+++ b/resources/payment_provider.md
@@ -91,7 +91,7 @@ If applicable, the installments data supported by the payment method type is det
 
 Most Payment Providers provide different installment based payments options.
 
-*Note:* At the moment, installments are only allowed for *credit_card* payment method type.
+***Note:*** At the moment, installments are only allowed for `credit_card` payment method type.
 
 | Field                   | Type          | Description                                                  |
 | :---------------------- | :------------ | :----------------------------------------------------------- |

--- a/resources/payment_provider.md
+++ b/resources/payment_provider.md
@@ -90,6 +90,7 @@ If applicable, the installments data supported by the payment method type is det
 #### Installments
 
 Most Payment Providers provide different installment based payments options.
+Installments are allowed only for *credit_card* payment method type.
 
 | Field                   | Type          | Description                                                  |
 | :---------------------- | :------------ | :----------------------------------------------------------- |

--- a/resources/payment_provider.md
+++ b/resources/payment_provider.md
@@ -90,7 +90,8 @@ If applicable, the installments data supported by the payment method type is det
 #### Installments
 
 Most Payment Providers provide different installment based payments options.
-Installments are allowed only for *credit_card* payment method type.
+
+*Note:* At the moment, installments are only allowed for *credit_card* payment method type.
 
 | Field                   | Type          | Description                                                  |
 | :---------------------- | :------------ | :----------------------------------------------------------- |


### PR DESCRIPTION
Updated Payments Provider docs to make it clear that the Installments option is only allowed for the credit card payment method type.