### PR TITLE
Add Stub .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+# Use a package of configuration called an orb.
+orbs:
+  # Declare a dependency on the welcome-orb
+  welcome: circleci/welcome-orb@0.4.1
+# Orchestrate or schedule a set of jobs
+workflows:
+  # Name the workflow "welcome"
+  welcome:
+    # Run the welcome/run job in its own container
+    jobs:
+      - welcome/run


### PR DESCRIPTION
So based on what i see on the last Circle CI build on => https://app.circleci.com/pipelines/github/TiendaNube/api-docs/501/workflows/188fc77a-7521-4f85-9146-4c1160c91f1d/jobs/502, and previous runs. 

It seems that the `.circleci/config.yml` has been always missing. I don't know if it's planned to have a building process as this is now more of a documentation repository but it could be useful for the time being just to have an stub build with circle.ci. 

This is a build with the changes i'm sending on this MR https://app.circleci.com/pipelines/github/bossiernesto/api-docs/1/workflows/9c06da68-b8cf-4033-93d0-39609f64c88d

An alternative could be to have a build based on a container rather from an orb, like the following example:

```
version: 2.1
jobs:
  build:
    machine:
      image: ubuntu-2004:202010-01
    steps:
      - checkout
      - run:
          name: "Stub testing"
          command: echo "This is an stub. Replace with valid step."
```          


