### PR TITLE
Fix PUT and DELETE methods on Discounts API collection

### DIFF
--- a/utils/postman/changelog.md
+++ b/utils/postman/changelog.md
@@ -2,15 +2,30 @@
 # Change Log
 All notable changes to the collection will be documented in this file.
  
+## [1.3.1] - 2021-05-24
+  
+Fix PUT and DELETE methods on Discounts API.
+
+### Changed
+- Updated the format of the paragraphs of Changelog.md
+
+
+### Fixed
+- Folder Discounts
+  - **PUT Create a Discount:** 
+    - `cart_id` and `line_items` replaced from integer to string on body request example.
+  - **DELETE Remove a discount associated with a cart from a specific line item:** 
+    - path parameter updated with `/line-items/{{line_item}}`
+ 
 ## [1.3.0] - 2021-05-19
   
 Abandoned Checkout API methods included according with documentation available at https://github.com/TiendaNube/api-docs/blob/master/resources/abandoned_checkout.md
 
 ### Added
 - Folder Abandoned Checkout
-  POST Create a discount coupon to the abandoned cart
-  GET Receive all abandoned carts
-  GET Receive a specific abandoned cart
+  - POST Create a discount coupon to the abandoned cart
+  - GET Receive all abandoned carts
+  - GET Receive a specific abandoned cart
 
 ### Changed
 
@@ -22,10 +37,10 @@ Discounts API methods included according with documentation available at http://
 
 ### Added
 - Folder Discounts
-  POST Create a Promotion
-  PUT Create a Discount
-  DELETE Remove a discount associated with a cart
-  DELETE Remove a discount associated with a cart from a specific line item
+  - POST Create a Promotion
+  - PUT Create a Discount
+  - DELETE Remove a discount associated with a cart
+  - DELETE Remove a discount associated with a cart from a specific line item
 
 ### Changed
 

--- a/utils/postman/postman.json
+++ b/utils/postman/postman.json
@@ -884,7 +884,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"promotion_id\": \"{{promotion_id}}\",\n  \"cart_id\": 12345,\n  \"line_items\": [\n    67890\n  ]\n}",
+							"raw": "{\n  \"promotion_id\": \"{{promotion_id}}\",\n  \"cart_id\": \"{{cart_id}}\",\n  \"line_items\": [\n    \"{{line_item}}\", //retrieved by the object data-line-item-id \n    \"{{line_item}}\"\n  ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -984,7 +984,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{api_url}}/{{store_id}}/discounts/carts/{{cart_id}}/promotions/{{promotion_id}}",
+							"raw": "https://{{api_url}}/{{store_id}}/discounts/carts/{{cart_id}}/promotions/{{promotion_id}}/line-items/{{line_item}}",
 							"protocol": "https",
 							"host": [
 								"{{api_url}}"
@@ -995,7 +995,9 @@
 								"carts",
 								"{{cart_id}}",
 								"promotions",
-								"{{promotion_id}}"
+								"{{promotion_id}}",
+								"line-items",
+								"{{line_item}}"
 							]
 						}
 					},
@@ -4116,6 +4118,10 @@
 		},
 		{
 			"key": "promotion_id",
+			"value": ""
+		},
+		{
+			"key": "line_item",
 			"value": ""
 		}
 	]


### PR DESCRIPTION
## [1.3.1] - 2021-05-24
  
Fix PUT and DELETE methods on Discounts API.

### Changed
- Updated the format of the paragraphs of Changelog.md

### Fixed
- Folder Discounts
  - **PUT Create a Discount:** 
    - `cart_id` and `line_items` replaced from integer to string on body request example.
  - **DELETE Remove a discount associated with a cart from a specific line item:** 
    - path parameter updated with `/line-items/{{line_item}}`