### PR TITLE
[Catalog Improvements] Limitar la creación de productos via API

### DIFF
--- a/resources/product.md
+++ b/resources/product.md
@@ -384,7 +384,7 @@ Returns the first Product found where one of its variants has the given SKU.
 
 ### POST /products
 
-Create a new Product
+Creates a new Product
 
 #### POST /products
 
@@ -401,6 +401,36 @@ Create a new Product
     "name": [
       "can't be blank"
     ]
+}
+```
+
+`HTTP/1.1 422 Unprocessable Entity`
+
+```json
+{
+    "code": 422,
+    "message": "Unprocessable Entity",
+    "description": "Store has reached maximum limit of 100000 allowed products"
+}
+```
+
+`HTTP/1.1 422 Unprocessable Entity`
+
+```json
+{
+    "code": 422,
+    "message": "Unprocessable Entity",
+    "description": "Product is not allowed to have more than 250 images"
+}
+```
+
+`HTTP/1.1 422 Unprocessable Entity`
+
+```json
+{
+    "code": 422,
+    "message": "Unprocessable Entity",
+    "description": "Product is not allowed to have more than 1000 variants"
 }
 ```
 


### PR DESCRIPTION
En [este PR](https://github.com/TiendaNube/tiendanube/pull/16351) limitamos la creación de productos via API mediante el endpoint POST /products. No se podrán crear productos nuevos utilizando este endpoint si la tienda supera 100k productos activos. También, todo request a este endpoint que supere las 1000 variantes o las 250 imágenes permitidas por producto, será rechazado.
Se agregan los mensajes de error correspondientes arrojados ante estas validaciones en el endpoint.