### PR TITLE
[Catalog Improvements] Limitar la creación de variantes de producto vía API

### DIFF
--- a/resources/product_variant.md
+++ b/resources/product_variant.md
@@ -219,6 +219,27 @@ Create a new Product Variant
 }
 ```
 
+`HTTP/1.1 422 Unprocessable Entity`
+
+```json
+{
+    "code": 422,
+    "message": "Unprocessable Entity",
+    "description": "Variants cannot be repeated"
+}
+```
+
+
+`HTTP/1.1 422 Unprocessable Entity`
+
+```json
+{
+    "code": 422,
+    "message": "Unprocessable Entity",
+    "description": "Product is not allowed to have more than 1000 variants"
+}
+```
+
 `HTTP/1.1 201 Created`
 
 ```json


### PR DESCRIPTION
En [este PR](https://github.com/TiendaNube/tiendanube/pull/16446) limitamos la creación de variantes de producto via API mediante el endpoint `POST /products/{id}/variants`. No se podrán crear variantes nuevas utilizando este endpoint si el producto tiene 1000 o más variantes activas.

Se agrega el mensaje de error correspondiente arrojado ante esta validación en el endpoint. También agrego el mensaje de error arrojado ante la validación de variantes repetidas.