### PR TITLE
[Catalog Improvements] Limitar la creación de imágenes de producto vía API

### DIFF
--- a/resources/product_image.md
+++ b/resources/product_image.md
@@ -150,6 +150,16 @@ Check the examples below for more details.
 }
 ```
 
+`HTTP/1.1 422 Unprocessable Entity`
+
+```json
+{
+  "code": 422,
+  "message": "Unprocessable Entity",
+  "description": "Product is not allowed to have more than 250 images"
+}
+```
+
 #### POST /products/1234/images
 
 ```json


### PR DESCRIPTION
En [este PR](https://github.com/TiendaNube/tiendanube/pull/16488) limitamos la creación de imágenes de producto via API mediante el endpoint `POST /products/{id}/images`. No se podrán crear imágenes nuevas utilizando este endpoint si el producto tiene 250 o más imágenes asociadas.

Se agrega el mensaje de error correspondiente arrojado ante esta validación en el endpoint.