### PR TITLE
[Catalog Improvements] Limitar la creación de categorías vía API (API docs)

### DIFF
--- a/resources/category.md
+++ b/resources/category.md
@@ -148,6 +148,16 @@ Create a new Category
 }
 ```
 
+`HTTP/1.1 422 Unprocessable Entity`
+
+```json
+{
+    "code": 422,
+    "message": "Unprocessable Entity",
+    "description": "Store has reached maximum limit of 5000 allowed categories"
+}
+```
+
 #### POST /categories
 
 ```json


### PR DESCRIPTION
En [este PR](https://github.com/TiendaNube/tiendanube/pull/16516) limitamos la creación de categorías via API mediante el endpoint `POST /categories`. No se podrán crear categorías nuevas utilizando este endpoint si la tienda tiene 5000 o más categorías activas.

Se agrega el mensaje de error correspondiente arrojado ante esta validación en el endpoint.