### PR TITLE
Update shipping_carrier.md

### DIFF
--- a/resources/shipping_carrier.md
+++ b/resources/shipping_carrier.md
@@ -53,8 +53,8 @@ The response object rates must be a JSON array of objects with the following fie
 
 | Property           | Explanation                                                                                                                                |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| name               | __(required)__ The name of the rate which buyers will see at checkout.                                                                     |
-| code               | __(required)__ A unique code associated with the carrier option code. It´s used to apply the settings over the rate.                       |
+| name               | __(required)__ The name of the rate which buyers will see at the storefront or checkout.                                                                     |
+| code               | __(required)__ A unique code associated with the carrier option code. It's used to apply the settings over the rate.                       |
 | price              | __(required)__ The rate's price that will be payed by the buyer.                                                                           |
 | currency           | __(required)__ The rate's currency. Currency codes must be specified according to [ISO 4217](https://www.currency-iso.org/en/home/tables/table-a1.html)                                                                                                     |
 | type               | __(required)__ The rate's type: _ship_ if it will be deliverd to a buyer's address or _pickup_ if it will be picked up by the buyer.       |


### PR DESCRIPTION
Updating the following:

- The property "name" is not only shown at the checkout but also at storefront (if it's enabled by the merchant).
- Modifying apostrophe symbol from (`) to (') to match the style of the rest of the doc.